### PR TITLE
Prevent NullPointerException in BroadcastReceiver

### DIFF
--- a/app/src/main/java/android/com/ericswpark/camsung/Receiver.kt
+++ b/app/src/main/java/android/com/ericswpark/camsung/Receiver.kt
@@ -24,8 +24,10 @@ class Receiver : BroadcastReceiver() {
 
     @RequiresApi(Build.VERSION_CODES.M)
     override fun onReceive(context: Context, intent: Intent?) {
-        when (intent!!.action) {
+        val action = intent?.action ?: return
+        when (action) {
             Intent.ACTION_BOOT_COMPLETED -> {
+
                 val sharedPref = context.getSharedPreferences("android.com.ericswpark.camsung.PREFERENCES",
                     Context.MODE_PRIVATE)
                 val startBootEnabled = (sharedPref.getInt("start_at_boot", 0) == 1)
@@ -40,9 +42,10 @@ class Receiver : BroadcastReceiver() {
                 }
             }
             ACTION_SET_CAMERA -> {
-                val data = intent.data?.toString()
+                val data = intent?.data?.toString()
 
                 when (data) {
+
                     "app://mute" -> {
                         muteCamera(context)
                     }


### PR DESCRIPTION
The `onReceive` method was using the non-null assertion operator `!!` on the `intent` parameter, which could lead to a `NullPointerException` if a broadcast with a null intent was received. 

This PR replaces the unsafe force-unwrap with a safe check: `val action = intent?.action ?: return`. This ensures that if the intent or its action is null, the method returns gracefully instead of crashing.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.